### PR TITLE
Add support for resolving from base url (and also better URL encoding support)

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,0 +1,122 @@
+{
+  //    ┬┌─┐╦ ╦╦╔╗╔╔╦╗┬─┐┌─┐
+  //    │└─┐╠═╣║║║║ ║ ├┬┘│
+  //  o└┘└─┘╩ ╩╩╝╚╝ ╩ ┴└─└─┘
+  //
+  // This file (`.jshintrc`) exists to help with consistency of code
+  // throughout this package, and throughout Sails and the Node-Machine project.
+  //
+  // To review what each of these options mean, see:
+  // http://jshint.com/docs/options
+  //
+  // (or: https://github.com/jshint/jshint/blob/master/examples/.jshintrc)
+
+
+
+  //////////////////////////////////////////////////////////////////////
+  // NOT SUPPORTED IN SOME JSHINT VERSIONS SO LEAVING COMMENTED OUT:
+  //////////////////////////////////////////////////////////////////////
+  // Prevent overwriting prototypes of native classes like `Array`.
+  // (doing this is _never_ ok in any of our packages that are intended
+  //  to be used as dependencies of other developers' modules and apps)
+  // "freeze": true,
+  //////////////////////////////////////////////////////////////////////
+
+
+  //////////////////////////////////////////////////////////////////////
+  // EVERYTHING ELSE:
+  //////////////////////////////////////////////////////////////////////
+
+  // Allow the use of `eval` and `new Function()`
+  // (we sometimes actually need to use these things)
+  "evil": true,
+
+  // Tolerate funny-looking dashes in RegExp literals.
+  // (see https://github.com/jshint/jshint/issues/159#issue-903547)
+  "regexdash": true,
+
+  // The potential runtime "Environments" (as defined by jshint)
+  // that the _style_ of code written in this package should be
+  // compatible with (not the code itself, of course).
+  "browser": true,
+  "node": true,
+  "wsh": true,
+
+  // Tolerate the use `[]` notation when dot notation would be possible.
+  // (this is sometimes preferable for readability)
+  "sub": true,
+
+  // Do NOT suppress warnings about mixed tabs and spaces
+  // (two spaces always, please; see `.editorconfig`)
+  "smarttabs": false,
+
+  // Suppress warnings about trailing whitespace
+  // (this is already enforced by the .editorconfig, so no need to warn as well)
+  "trailing": false,
+
+  // Suppress warnings about the use of expressions where fn calls or assignments
+  // are expected, and about using assignments where conditionals are expected.
+  // (while generally a good idea, without this setting, JSHint needlessly lights up warnings
+  //  in existing, working code that really shouldn't be tampered with.  Pandora's box and all.)
+  "expr": true,
+  "boss": true,
+
+  // Do NOT suppress warnings about using functions inside loops
+  // (in the general case, we should be using iteratee functions with `_.each()`
+  //  or `Array.prototype.forEach()` instead of `for` or `while` statements
+  //  anyway.  This warning serves as a helpful reminder.)
+  "loopfunc": false,
+
+  // Suppress warnings about "weird constructions"
+  // i.e. allow code like:
+  // ```
+  //  (new (function OneTimeUsePrototype () { } ))
+  // ```
+  //
+  // (sometimes order of operations in JavaScript can be scary.  There is
+  //  nothing wrong with using an extra set of parantheses when the mood
+  //  strikes or you get "that special feeling".)
+  "supernew": true,
+
+  // Do NOT allow backwards, node-dependency-style commas.
+  // (while this code style choice was used by the project in the past,
+  //  we have since standardized these practices to make code easier to
+  //  read, albeit a bit less exciting)
+  "laxcomma": false,
+
+  // Strictly enforce the consistent use of single quotes.
+  // (this is a convention that was established primarily to make it easier
+  //  to grep [or FIND+REPLACE in Sublime] particular string literals in
+  //  JavaScript [.js] files.  Note that JSON [.json] files are, of course,
+  //  still written exclusively using double quotes around key names and
+  //  around string literals.)
+  "quotmark": "single",
+
+  // Do NOT suppress warnings about the use of `==null` comparisons.
+  // (please be explicit-- use Lodash or `require('util')` and call
+  //  either `.isNull()` or `.isUndefined()`)
+  "eqnull": false,
+
+  // Strictly enforce the use of curly braces with `if`, `else`, and `switch`
+  // as well as, much less commonly, `for` and `while` statements.
+  // (this is just so that all of our code is consistent, and to avoid bugs)
+  "curly": true,
+
+  // Strictly enforce the use of `===` and `!==`.
+  // (this is always a good idea.  Check out "Truth, Equality, and JavaScript"
+  //  by Angus Croll [the author of "If Hemmingway Wrote JavaScript"] for more
+  //  explanation as to why.)
+  "eqeqeq": true,
+
+  // Allow initializing variables to `undefined`.
+  // For more information, see:
+  //  • https://jslinterrors.com/it-is-not-necessary-to-initialize-a-to-undefined
+  //  • https://github.com/jshint/jshint/issues/1484
+  //
+  // (it is often very helpful to explicitly clarify the initial value of
+  //  a local variable-- especially for folks new to more advanced JavaScript
+  //  and who might not recognize the subtle, yet critically important differences between our seemingly
+  //  between `null` and `undefined`, and the impact on `typeof` checks)
+  "-W080": true
+
+}

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,10 @@ language: node_js
 node_js:
   - "0.10"
   - "0.12"
+  - "4"
+  - "5"
+  - "6"
+  - "node"
 
 # whitelisted branches
 branches:

--- a/machines/is-url.js
+++ b/machines/is-url.js
@@ -43,7 +43,7 @@ module.exports = {
     var re_weburl = new RegExp(
       "^" +
       // protocol identifier
-      "(?:(?:https?|ftp)://)" +
+      "(?:(?:[a-z][a-z0-9]+)://)" +
       // user:pass authentication
       "(?:\\S+(?::\\S*)?@)?" +
       "(?:" +

--- a/machines/resolve.js
+++ b/machines/resolve.js
@@ -7,7 +7,7 @@ module.exports = {
   description: 'Build a sanitized, fully-qualified version of the provided URL.',
 
 
-  extendedDescription: 'Given a URL or URL segment, returns a fully-qualified URL with trailing slashes stripped off.  For example, if a valid protocol is provided (e.g. "https://") and the original URL contains no trailing slashes, the URL returned will be identical to what was passed in.  If the provided URL begins with "//", it will be replaced with "http://".  If the provided URL does not start with a usable protocol, "http://" will be prepended.  If the URL cannot be sanitized, the `invalid` exit will be triggered.',
+  extendedDescription: 'Given a URL, returns a fully-qualified URL with trailing slashes stripped off.  For example, if a valid protocol is provided (e.g. "https://") and the original URL contains no trailing slashes, the URL returned will be identical to what was passed in.  If the provided URL begins with "//", it will be replaced with "http://".  If the provided URL does not start with a usable protocol, "http://" will be prepended.  If the URL cannot be sanitized, the `error` exit will be triggered.',
 
 
   sync: true,
@@ -65,7 +65,7 @@ module.exports = {
 
     // Now check that what we ended up with is actually valid.
     if (!Urls.isUrl({string: fullyQualifiedUrl}).execSync()) {
-      return exits.error(new Error('The provided URL was not valid.'));
+      return exits.error(new Error('The provided URL (`'+inputs.url+'`) was not a valid, fully-qualified URL.  Make sure it includes the hostname (e.g. "example.com").'));
     }
 
     // Return the fully-qualified URL through the `success` exit.

--- a/machines/resolve.js
+++ b/machines/resolve.js
@@ -103,6 +103,7 @@ module.exports = {
         }
 
         // Now resolve the `url` relative to the the `baseUrl` using Node's `url.resolve()`.
+        // (This also escapes characters like spaces, etc.)
         var finalResolvedUrl = url.resolve(resolvedBaseUrl, inputs.url);
 
         // Now, one last time, trim off any trailing slashes.
@@ -122,6 +123,10 @@ module.exports = {
         if (resolvedPrimaryUrl === '') {
           throw new Error('The provided URL (`'+inputs.url+'`) was not a valid, fully-qualified URL.  Make sure it includes the hostname (e.g. "example.com"), or leave this primary URL as a path like "/foo/bar" and include a base URL (e.g. "api.example.com/pets").');
         }
+
+        // Now use Node's `url.resolve()` to escape characters.
+        resolvedPrimaryUrl = url.resolve(resolvedPrimaryUrl, '');
+
         return resolvedPrimaryUrl;
       }
 
@@ -139,9 +144,9 @@ module.exports = {
       handleResolvingUrl: function (origUrl){
 
         // Build our best attempt at a fully-qualified URL.
-        var fullyQualifiedUrl = (function (){
+        var fullyQualifiedUrl = (function _ensureProtocol(){
           // If a protocol is already included in URL, leave it alone.
-          if (origUrl.match(/^(https?:\/\/|ftp:\/\/)/)) {
+          if (origUrl.match(/^([a-z][a-z0-9]+:\/\/)/)) {
             return origUrl;
           }
           // If protocol is invalid, but sort of makes sense ("//"), change it to `http`.
@@ -156,6 +161,9 @@ module.exports = {
 
         // Trim off any trailing slashes.
         fullyQualifiedUrl = fullyQualifiedUrl.replace(/\/*$/, '');
+
+        // Now use Node's `url.resolve()` to escape characters like spaces.
+        fullyQualifiedUrl = url.resolve(fullyQualifiedUrl, '');
 
         // Now check that what we ended up with is actually valid.
         if (!Urls.isUrl({string: fullyQualifiedUrl}).execSync()) {

--- a/machines/resolve.js
+++ b/machines/resolve.js
@@ -97,6 +97,6 @@ module.exports = {
 
     // Return the fully-qualified URL through the `success` exit.
     return exits.success(fullyQualifiedUrl);
-  },
+  }
 
 };

--- a/machines/resolve.js
+++ b/machines/resolve.js
@@ -20,7 +20,11 @@ module.exports = {
   'Optionally, this machine _also_ allows a base URL (`baseUrl`) to be provided.  This allows a URL path (like `/foo/bar`) to be '+
   'provided as the primary URL, as long as a valid URL with a hostname is provided as the base URL.  To stick with our example from '+
   'above, if `/foo/bar` is passed in as the primary URL (`url`), and a valid base URL-- say, `api.example.com/pets` _is also provided_, '+
-  'then, instead of failing, this machine will return `http://api.example.com/pets/foo/bar`.'+
+  'then, instead of failing, this machine will return `http://api.example.com/pets/foo/bar`.\n'+
+  '\n'+
+  '### URL encoding\n'+
+  '> This also ensures that the provided URL strings do not contain invalid characters by escaping spaces as `%20`, etc.\n'+
+  '> See [the Node.js docs](https://nodejs.org/api/url.html#url_escaped_characters) for reference.'+
   '',
 
 
@@ -95,17 +99,17 @@ module.exports = {
         // > URL encodes, etc.)  So our goal is just to catch some of the major stuff that would normally
         // > slip through the cracks and cause `url.resolve()` to fail silently in an unexpected way.
         if (inputs.url.match(/^(https?:\/\/|ftp:\/\/)/)) {
-          throw new Error('The provided primary URL (`'+inputs.url+'`) has an unexpected format.  Because a base URL (`'+inputs.baseUrl+'`) was also specified, the primary URL should be provided as a URL path, like "/foo/bar".');
+          throw new Error('The provided primary URL (`'+inputs.url+'`) has an unexpected format.  Because a base URL (`'+inputs.baseUrl+'`) was also specified, the primary URL should be provided as a URL path, like "/foo/bar".  It should not begin with a protocol like "http://".');
         }
 
         // Now resolve the `url` relative to the the `baseUrl` using Node's `url.resolve()`.
         var finalResolvedUrl = url.resolve(resolvedBaseUrl, inputs.url);
 
         // Now, one last time, trim off any trailing slashes.
-        finalResolvedUrl = finalResolvedUrl.replace(/\/*$/, '');
+        finalResolvedUrl = fullyQualifiedUrl.replace(/\/*$/, '');
 
         // And that's it!
-        return resolvedBaseUrl;
+        return finalResolvedUrl;
       }// ‡
       //  ╔═╗╔╦╗╦ ╦╔═╗╦═╗╦ ╦╦╔═╗╔═╗
       //  ║ ║ ║ ╠═╣║╣ ╠╦╝║║║║╚═╗║╣

--- a/machines/resolve.js
+++ b/machines/resolve.js
@@ -7,7 +7,21 @@ module.exports = {
   description: 'Build a sanitized, fully-qualified version of the provided URL.',
 
 
-  extendedDescription: 'Given a URL, returns a fully-qualified URL with trailing slashes stripped off.  For example, if a valid protocol is provided (e.g. "https://") and the original URL contains no trailing slashes, the URL returned will be identical to what was passed in.  If the provided URL begins with "//", it will be replaced with "http://".  If the provided URL does not start with a usable protocol, "http://" will be prepended.  If the URL cannot be sanitized, the `error` exit will be triggered.',
+  extendedDescription:
+  'Given a URL, this returns a fully-qualified URL with trailing slashes stripped off.  It also infers a protocol, if necessary.  '+
+  'For example, if a valid protocol is provided (e.g. "https://") and the original URL contains no trailing slashes, the URL '+
+  'returned will be identical to what was passed in.  If the provided URL begins with "//", it will be replaced with "http://".  '+
+  'If the provided URL does not start with a usable protocol (e.g. "google.com"), then "http://" will be prepended.  If the URL '+
+  'cannot be sanitized (e.g. if it is missing a hostname, or altogether malformed), then the `error` exit will be triggered.  '+
+  'In other words, if `/foo/bar` is passed in as the URL (and assuming the optional base URL is not provided), then this machine '+
+  'will fail.\n'+
+  '\n'+
+  '### Resolving relative to a base URL\n'+
+  'Optionally, this machine _also_ allows a base URL (`baseUrl`) to be provided.  This allows a URL path (like `/foo/bar`) to be '+
+  'provided as the primary URL, as long as a valid URL with a hostname is provided as the base URL.  To stick with our example from '+
+  'above, if `/foo/bar` is passed in as the primary URL (`url`), and a valid base URL-- say, `api.example.com/pets` _is also provided_, '+
+  'then, instead of failing, this machine will return `http://api.example.com/pets/foo/bar`.'+
+  '',
 
 
   sync: true,
@@ -21,7 +35,7 @@ module.exports = {
     url: {
       friendlyName: 'URL',
       description: 'The URL to resolve, with or without the protocol prefix (e.g. "http://").',
-      extendedDescription: 'If a `baseUrl` is specified, then this URL should be specified as a URL path (e.g. "/foo").',
+      extendedDescription: 'If a `baseUrl` is specified, then this URL should be specified as a URL path (e.g. "/foo").  Otherwise, this _must_ include the hostname (e.g. `api.example.com`).',
       example: 'www.example.com/search',
       required: true
     },
@@ -30,7 +44,7 @@ module.exports = {
       friendlyName: 'Base URL',
       description: 'Optional base URL to resolve against, with or without the protocol prefix (e.g. "http://").',
       extendedDescription: 'If specified, this _must_ include the hostname (e.g. `api.example.com`).  It may also include a path (e.g. `http://api.example.com/pets`).',
-      example: 'https://api.example.com/pets'
+      example: 'api.example.com/pets'
     }
 
   },

--- a/machines/resolve.js
+++ b/machines/resolve.js
@@ -20,9 +20,17 @@ module.exports = {
 
     url: {
       friendlyName: 'URL',
+      description: 'The URL to resolve, with or without the protocol prefix (e.g. "http://").',
+      extendedDescription: 'If a `baseUrl` is specified, then this URL should be specified as a URL path (e.g. "/foo").',
       example: 'www.example.com/search',
-      description: 'The URL to sanitize, with or without the protocol prefix (e.g. "http://").',
       required: true
+    },
+
+    baseUrl: {
+      friendlyName: 'Base URL',
+      description: 'Optional base URL to resolve against, with or without the protocol prefix (e.g. "http://").',
+      extendedDescription: 'If specified, this _must_ include the hostname (e.g. `api.example.com`).  It may also include a path (e.g. `http://api.example.com/pets`).',
+      example: 'https://api.example.com/pets'
     }
 
   },
@@ -32,7 +40,7 @@ module.exports = {
 
     success: {
       outputFriendlyName: 'Resolved URL',
-      outputDescription: 'A sanitized, fully-qualified version of the input URL.',
+      outputDescription: 'A sanitized, fully-qualified URL.',
       outputExample: 'http://www.example.com/search'
     }
 
@@ -43,6 +51,25 @@ module.exports = {
 
     // Get a handle to this pack.
     var Urls = require('../');
+
+
+    //  ╦╔═╗  ┌┐ ┌─┐┌─┐┌─┐  ┬ ┬┬─┐┬    ┬ ┬┌─┐┌─┐  ┌─┐┬─┐┌─┐┬  ┬┬┌┬┐┌─┐┌┬┐
+    //  ║╠╣   ├┴┐├─┤└─┐├┤   │ │├┬┘│    │││├─┤└─┐  ├─┘├┬┘│ │└┐┌┘│ ││├┤  ││
+    //  ╩╚    └─┘┴ ┴└─┘└─┘  └─┘┴└─┴─┘  └┴┘┴ ┴└─┘  ┴  ┴└─└─┘ └┘ ┴─┴┘└─┘─┴┘ooo
+    if (inputs.baseUrl !== undefined) {
+      // TODO
+      throw new Error('TODO');
+    }
+
+
+    // --•
+    //  ╔═╗╔╦╗╦ ╦╔═╗╦═╗╦ ╦╦╔═╗╔═╗
+    //  ║ ║ ║ ╠═╣║╣ ╠╦╝║║║║╚═╗║╣
+    //  ╚═╝ ╩ ╩ ╩╚═╝╩╚═╚╩╝╩╚═╝╚═╝ooo
+    //  ┌─    ┌┐┌┌─┐  ┌┐ ┌─┐┌─┐┌─┐  ┬ ┬┬─┐┬    ┬ ┬┌─┐┌─┐  ┌─┐┬─┐┌─┐┬  ┬┬┌┬┐┌─┐┌┬┐    ─┐
+    //  │───  ││││ │  ├┴┐├─┤└─┐├┤   │ │├┬┘│    │││├─┤└─┐  ├─┘├┬┘│ │└┐┌┘│ ││├┤  ││  ───│
+    //  └─    ┘└┘└─┘  └─┘┴ ┴└─┘└─┘  └─┘┴└─┴─┘  └┴┘┴ ┴└─┘  ┴  ┴└─└─┘ └┘ ┴─┴┘└─┘─┴┘    ─┘
+    // Otherwise, no `baseUrl` was provided.
 
     // Build our best attempt at a fully-qualified URL.
     var fullyQualifiedUrl = (function (){

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "machinepack-urls",
-  "version": "5.0.0",
+  "version": "6.0.0-0",
   "description": "Machines for working with URL strings.",
   "scripts": {
     "test": "node ./node_modules/test-machinepack-mocha/bin/testmachinepack-mocha.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "machinepack-urls",
-  "version": "6.0.0-0",
+  "version": "6.0.0-1",
   "description": "Machines for working with URL strings.",
   "scripts": {
     "test": "node ./node_modules/test-machinepack-mocha/bin/testmachinepack-mocha.js"


### PR DESCRIPTION
First, see https://github.com/mikermcneil/machinepack-urls/pull/2
(this PR includes that ^^)

First and foremost, this PR adds better support for URL encoding.

Secondly, it also adds support for dealing with resolving a URL from a base URL.  It's kind of like https://nodejs.org/api/url.html#url_url_resolve_from_to, but it has much more restricted functionality (and doesn't do `href`-style resolution).  Instead, it's the standard thing you need when e.g. building an endpoint URL for an API.

By including this in mp-urls, besides being useful in general, it makes it trivial in mp-http to do a much safer version of the baseUrl logic than we're doing currently.

Last but not least, it adds .jshintrc, etc.
